### PR TITLE
Fix crash in overview plots when no results exist

### DIFF
--- a/webapp/pages_/impl/overview_plotting.py
+++ b/webapp/pages_/impl/overview_plotting.py
@@ -120,7 +120,8 @@ def _draw_plot(  # noqa: PLR0913
             "x" if x in ERROR_STATUSES else "circle" for x in df["status"].to_numpy()
         ]
         fig.update_traces(mode="lines+markers", marker={"symbol": symbol})
-    fig.add_hline(y=median_, line_dash="dash", line={"color": "lightgrey"})
+    if not pd.isna(median_):
+        fig.add_hline(y=median_, line_dash="dash", line={"color": "lightgrey"})
 
     # Add baseline if baseline data is available
     if y_is_numeric:


### PR DESCRIPTION
## Problem

Opening the Kraken overview when there are no results yet to plot produces an ugly error:

```
TypeError: boolean value of NA is ambiguous
  File "webapp/pages_/impl/overview_plotting.py", line 123, in _draw_plot
    fig.add_hline(y=median_, line_dash="dash", line={"color": "lightgrey"})
```

## Cause

With no results, `median_` is `pd.NA`. The title format renders it as `<NA>` (no crash), but `fig.add_hline(y=pd.NA)` triggers plotly's internal value comparison which calls `bool(pd.NA)` → "boolean value of NA is ambiguous".

## Fix

Guard the median hline with a `pd.isna` check, consistent with the existing baseline hline guards in the same function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)