### PR TITLE
Return UNKNOWN job state when lookup fails and treat it as success

### DIFF
--- a/airflow_src/dags/impl/processor_impl.py
+++ b/airflow_src/dags/impl/processor_impl.py
@@ -465,7 +465,9 @@ def check_job_result(*, quanting_env: dict, job_id: str, ti: TaskInstance) -> di
 
     logging.info(f"Job {job_id} exited with status {job_status}.")
 
-    if job_status == JobStates.COMPLETED:
+    # treat UNKNOWN (for slurm: neither scontrol nor sacct could determine the state) as a successful
+    # completion: if the guess is wrong, downstream tasks fail anyway on the missing outputs
+    if job_status in (JobStates.COMPLETED, JobStates.UNKNOWN):
         return {"time_elapsed": time_elapsed}
 
     if job_status in [JobStates.FAILED, JobStates.TIMEOUT] or job_status.startswith(

--- a/airflow_src/plugins/common/constants.py
+++ b/airflow_src/plugins/common/constants.py
@@ -11,6 +11,9 @@ CLUSTER_SSH_COMMAND_TIMEOUT = 60
 DEFAULT_JOB_SCRIPT_NAME = "submit_job.sh"
 CLUSTER_BASE_WORKING_DIR_NAME = "jobs"
 
+# returned as the elapsed time when it cannot be determined (e.g. sacct unavailable)
+DUMMY_TIME_ELAPSED = "00:00:00"
+
 
 OUTPUT_FOLDER_PREFIX = "out_"
 

--- a/airflow_src/plugins/common/keys.py
+++ b/airflow_src/plugins/common/keys.py
@@ -189,6 +189,7 @@ class JobStates:
     FAILED: str = "FAILED"
     TIMEOUT: str = "TIMEOUT"
     OUT_OF_MEMORY: str = "OUT_OF_ME"  # it is displayed "OUT_OF_ME+", so only startwith() comparisons here
+    UNKNOWN: str = "UNKNOWN"  # sentinel for when neither scontrol nor sacct can determine the state; not a real slurm state
 
 
 class CustomAlphaDiaStates:

--- a/airflow_src/plugins/jobs/job_handler.py
+++ b/airflow_src/plugins/jobs/job_handler.py
@@ -9,8 +9,8 @@ import logging
 from datetime import datetime
 
 from airflow.exceptions import AirflowFailException
-from common.constants import CLUSTER_BASE_WORKING_DIR_NAME
-from common.keys import QuantingEnv
+from common.constants import CLUSTER_BASE_WORKING_DIR_NAME, DUMMY_TIME_ELAPSED
+from common.keys import JobStates, QuantingEnv
 from sensors.ssh_utils import ssh_execute
 
 from shared.keys import JobEngines
@@ -178,9 +178,13 @@ class SlurmSSHJobHandler(JobHandler):
         """
         return "\n".join(
             [
-                f"SACCT_OUT=$(sacct -l --parsable2 -j {job_id})",
+                f"SACCT_OUT=$(sacct -l --parsable2 -j {job_id} 2>/dev/null)",
+                "if [ $? -eq 0 ]; then",
                 "echo \"$SACCT_OUT\" | awk -F'|' 'NR==1{for(i=1;i<=NF;i++)if($i==\"Elapsed\")c=i}END{print $c}'",
                 'echo "$SACCT_OUT"',
+                "else",
+                f'echo "{DUMMY_TIME_ELAPSED}"',
+                "fi",
                 f"cat {slurm_output_file_path}",
             ]
         )
@@ -191,6 +195,7 @@ class SlurmSSHJobHandler(JobHandler):
 
         Uses `scontrol` to get the state and falls back to `sacct` (more expensive) only if
         `scontrol` returns an error (e.g. the job has been purged from the queue).
+        If both fail to determine the state, "UNKNOWN" is returned.
 
         Its only output must be the job status.
         """
@@ -200,9 +205,9 @@ class SlurmSSHJobHandler(JobHandler):
                 "if [ $? -eq 0 ]; then",
                 "ST=$(echo \"$JOB_INFO\" | grep JobState | awk -F 'JobState=' '{print $2}' | awk -F ' ' '{print $1}')",
                 "else",
-                f"ST=$(sacct -j {job_id} -o State | awk 'FNR == 3 {{print $1}}')",
+                f"ST=$(sacct -j {job_id} -o State 2>/dev/null | awk 'FNR == 3 {{print $1}}')",
                 "fi",
-                "echo $ST",
+                f'echo "${{ST:-{JobStates.UNKNOWN}}}"',
             ]
         )
 
@@ -237,7 +242,7 @@ class SlurmNoSacctSSHJobHandler(SlurmSSHJobHandler):
         del job_id  # unused
         return "\n".join(
             [
-                "TIME_ELAPSED=00:00:00",
+                f"TIME_ELAPSED={DUMMY_TIME_ELAPSED}",
                 "echo $TIME_ELAPSED",
                 f"cat {slurm_output_file_path}",
             ]
@@ -247,12 +252,15 @@ class SlurmNoSacctSSHJobHandler(SlurmSSHJobHandler):
     def _get_job_state_cmd(job_id: str) -> str:
         """Shell command to print the status of a job with a given job id.
 
+        Uses `scontrol`; if it fails to determine the state (e.g. the job has been
+        purged from the queue), "UNKNOWN" is returned.
+
         Its only output must be the job status.
         """
         return "\n".join(
             [
-                f"ST=$(scontrol show job {job_id} | grep JobState | awk -F 'JobState=' '{{print $2}}' | awk -F ' ' '{{print $1}}')",
-                "echo $ST",
+                f"ST=$(scontrol show job {job_id} 2>/dev/null | grep JobState | awk -F 'JobState=' '{{print $2}}' | awk -F ' ' '{{print $1}}')",
+                f'echo "${{ST:-{JobStates.UNKNOWN}}}"',
             ]
         )
 

--- a/airflow_src/plugins/jobs/job_handler.py
+++ b/airflow_src/plugins/jobs/job_handler.py
@@ -227,6 +227,7 @@ class SlurmSSHJobHandler(JobHandler):
         return (t.hour * 3600) + (t.minute * 60) + t.second
 
 
+# TODO: this could be removed now as SlurmSSHJobHandler is robust against sacct not being available
 class SlurmNoSacctSSHJobHandler(SlurmSSHJobHandler):
     """A Slurm job handler that works without Slurm accounting (`sacct` command) installed.
 

--- a/airflow_src/tests/dags/impl/test_processor_impl.py
+++ b/airflow_src/tests/dags/impl/test_processor_impl.py
@@ -682,6 +682,32 @@ def test_check_job_result_happy_path(
 
 @patch("dags.impl.processor_impl.put_xcom")
 @patch("dags.impl.processor_impl.get_job_result")
+def test_check_job_result_unknown_state_treated_as_success(
+    mock_get_job_result: MagicMock,
+    mock_put_xcom: MagicMock,
+) -> None:
+    """Test that an UNKNOWN job state is treated as a successful completion."""
+    quanting_env = {
+        QuantingEnv.RAW_FILE_ID: "test_file.raw",
+        QuantingEnv.PROJECT_ID: "PID1",
+        QuantingEnv.SETTINGS_NAME: "test_settings",
+        QuantingEnv.SETTINGS_VERSION: 1,
+        QuantingEnv.JOB_ENGINE: "slurm",
+        QuantingEnv.METRICS_TYPE: "alphadia",
+    }
+
+    mock_get_job_result.return_value = (JobStates.UNKNOWN, 522)
+    mock_ti = MagicMock()
+
+    # when
+    result = check_job_result(quanting_env=quanting_env, job_id="12345", ti=mock_ti)
+
+    assert result == {"time_elapsed": 522}
+    mock_put_xcom.assert_not_called()
+
+
+@patch("dags.impl.processor_impl.put_xcom")
+@patch("dags.impl.processor_impl.get_job_result")
 def test_check_job_result_unknown_job_status(
     mock_get_job_result: MagicMock,
     mock_put_xcom: MagicMock,

--- a/airflow_src/tests/plugins/jobs/test_job_handler.py
+++ b/airflow_src/tests/plugins/jobs/test_job_handler.py
@@ -93,9 +93,9 @@ def test_get_job_status_returns_correctly(
         'ST=$(echo "$JOB_INFO" | grep JobState | '
         "awk -F 'JobState=' '{print $2}' | awk -F ' ' '{print $1}')\n"
         "else\n"
-        "ST=$(sacct -j 12345 -o State | awk 'FNR == 3 {print $1}')\n"
+        "ST=$(sacct -j 12345 -o State 2>/dev/null | awk 'FNR == 3 {print $1}')\n"
         "fi\n"
-        "echo $ST"
+        'echo "${ST:-UNKNOWN}"'
     )
     mock_ssh_execute.assert_called_once_with(expected_command)
 
@@ -114,18 +114,22 @@ def test_get_job_result_returns_correct_job_status_and_time_elapsed(
     assert job_status == "COMPLETED"
     assert time_elapsed == 8 * 60 + 42
     expected_command = (
-        "SACCT_OUT=$(sacct -l --parsable2 -j 12345)\n"
+        "SACCT_OUT=$(sacct -l --parsable2 -j 12345 2>/dev/null)\n"
+        "if [ $? -eq 0 ]; then\n"
         "echo \"$SACCT_OUT\" | awk -F'|' 'NR==1{for(i=1;i<=NF;i++)if($i==\"Elapsed\")c=i}END{print $c}'\n"
         'echo "$SACCT_OUT"\n'
+        "else\n"
+        'echo "00:00:00"\n'
+        "fi\n"
         "cat /path/to/slurm_base_path/jobs/*/slurm-12345.out\n"
         "JOB_INFO=$(scontrol show job 12345 2>/dev/null)\n"
         "if [ $? -eq 0 ]; then\n"
         'ST=$(echo "$JOB_INFO" | grep JobState | '
         "awk -F 'JobState=' '{print $2}' | awk -F ' ' '{print $1}')\n"
         "else\n"
-        "ST=$(sacct -j 12345 -o State | awk 'FNR == 3 {print $1}')\n"
+        "ST=$(sacct -j 12345 -o State 2>/dev/null | awk 'FNR == 3 {print $1}')\n"
         "fi\n"
-        "echo $ST"
+        'echo "${ST:-UNKNOWN}"'
     )
     mock_ssh_execute.assert_called_once_with(expected_command)
 
@@ -161,9 +165,9 @@ def test_no_sacct_get_job_status_returns_correctly(
     job_status = SlurmNoSacctSSHJobHandler().get_job_status("12345")
     assert job_status == "RUNNING"
     expected_command = (
-        "ST=$(scontrol show job 12345 | grep JobState | "
+        "ST=$(scontrol show job 12345 2>/dev/null | grep JobState | "
         "awk -F 'JobState=' '{print $2}' | awk -F ' ' '{print $1}')\n"
-        "echo $ST"
+        'echo "${ST:-UNKNOWN}"'
     )
     mock_ssh_execute.assert_called_once_with(expected_command)
 
@@ -185,8 +189,8 @@ def test_no_sacct_get_job_result_returns_correct_job_status_and_time_elapsed(
         "TIME_ELAPSED=00:00:00\n"
         "echo $TIME_ELAPSED\n"
         "cat /path/to/slurm_base_path/jobs/*/slurm-12345.out\n"
-        "ST=$(scontrol show job 12345 | grep JobState | "
+        "ST=$(scontrol show job 12345 2>/dev/null | grep JobState | "
         "awk -F 'JobState=' '{print $2}' | awk -F ' ' '{print $1}')\n"
-        "echo $ST"
+        'echo "${ST:-UNKNOWN}"'
     )
     mock_ssh_execute.assert_called_once_with(expected_command)


### PR DESCRIPTION
Be robust against availability of `sacct`