### PR TITLE
warn when a raw file maps to multiple output folders per group

### DIFF
--- a/webapp/pages_/impl/overview_file_selection.py
+++ b/webapp/pages_/impl/overview_file_selection.py
@@ -65,6 +65,8 @@ def _show_output_folders(file_ids: list) -> None:
 
     Multiple runs of the same settings on a raw file write to the same output folder,
     so identical folders within a settings/type group are collapsed to a single entry.
+    If a raw file still maps to more than one distinct output folder within a group, this
+    is flagged as a warning.
     """
     output_folders_df = get_output_folders(file_ids)
     output_folders_df = output_folders_df[
@@ -90,6 +92,18 @@ def _show_output_folders(file_ids: list) -> None:
                 f"**{settings_name}** (v{settings_version}, {metrics_type}) — {len(output_paths)} folders:"
             )
             st.code("\n".join(output_paths))
+
+            raw_file_folder_counts = group.groupby("raw_file_id").size()
+            multi_folder_raw_files = raw_file_folder_counts[raw_file_folder_counts > 1]
+            if not multi_folder_raw_files.empty:
+                multi_folder_str = "\n- ".join(
+                    f"{raw_file_id} ({count} folders)"
+                    for raw_file_id, count in multi_folder_raw_files.items()
+                )
+                st.warning(
+                    f"Warning: the following {len(multi_folder_raw_files)} raw files have "
+                    f"more than one output folder in this group:\n- {multi_folder_str}"
+                )
 
 
 def _show_output_folders_button(

--- a/webapp/tests/pages_/impl/test_overview_file_selection.py
+++ b/webapp/tests/pages_/impl/test_overview_file_selection.py
@@ -36,6 +36,62 @@ def test_show_output_folders_collapses_repeated_runs_of_one_setting(
 
 @patch("pages_.impl.overview_file_selection.st")
 @patch("pages_.impl.overview_file_selection.get_output_folders")
+def test_show_output_folders_warns_on_raw_file_with_multiple_folders(
+    mock_get_output_folders: MagicMock,
+    mock_st: MagicMock,
+) -> None:
+    """Test that a raw file with more than one output folder in a group is flagged."""
+    # f1 ran twice with the same setting but wrote to two distinct folders
+    mock_get_output_folders.return_value = pd.DataFrame(
+        {
+            "raw_file_id": ["f1", "f1", "f2"],
+            "settings_name": ["s1", "s1", "s1"],
+            "settings_version": [1, 1, 1],
+            "type": ["alphadia", "alphadia", "alphadia"],
+            "output_path": ["/out/f1/a", "/out/f1/b", "/out/f2/a"],
+        }
+    )
+    mock_st.expander.return_value.__enter__ = MagicMock()
+    mock_st.expander.return_value.__exit__ = MagicMock()
+
+    # when
+    _show_output_folders(["f1", "f2"])
+
+    # then: f1 (2 folders) is flagged, f2 is not
+    mock_st.warning.assert_called_once()
+    warning_message = mock_st.warning.call_args[0][0]
+    assert "f1 (2 folders)" in warning_message
+    assert "f2" not in warning_message
+
+
+@patch("pages_.impl.overview_file_selection.st")
+@patch("pages_.impl.overview_file_selection.get_output_folders")
+def test_show_output_folders_no_warning_when_folders_unique_per_raw_file(
+    mock_get_output_folders: MagicMock,
+    mock_st: MagicMock,
+) -> None:
+    """Test that no warning is shown when each raw file maps to a single folder per group."""
+    mock_get_output_folders.return_value = pd.DataFrame(
+        {
+            "raw_file_id": ["f1", "f2"],
+            "settings_name": ["s1", "s1"],
+            "settings_version": [1, 1],
+            "type": ["alphadia", "alphadia"],
+            "output_path": ["/out/f1/a", "/out/f2/a"],
+        }
+    )
+    mock_st.expander.return_value.__enter__ = MagicMock()
+    mock_st.expander.return_value.__exit__ = MagicMock()
+
+    # when
+    _show_output_folders(["f1", "f2"])
+
+    # then
+    mock_st.warning.assert_not_called()
+
+
+@patch("pages_.impl.overview_file_selection.st")
+@patch("pages_.impl.overview_file_selection.get_output_folders")
 def test_show_output_folders_no_folders(
     mock_get_output_folders: MagicMock,
     mock_st: MagicMock,


### PR DESCRIPTION
"show output folders" has a warning and show (per group) if a raw file has more than one metrics for that group