### PR TITLE
allow instrument-wide overwrite via the overwrite_file_id variables

### DIFF
--- a/airflow_src/dags/impl/handler_impl.py
+++ b/airflow_src/dags/impl/handler_impl.py
@@ -8,6 +8,7 @@ from airflow.exceptions import AirflowFailException, AirflowSkipException
 from airflow.models import TaskInstance
 from common.keys import (
     DAG_DELIMITER,
+    INSTRUMENT_OVERWRITE_PREFIX,
     AcquisitionMonitorErrors,
     AirflowVars,
     DagContext,
@@ -148,9 +149,8 @@ def compute_checksum(ti: TaskInstance, **kwargs) -> bool:
                 f"{file_info=}\n"
             )
 
-            if (
-                get_airflow_variable(AirflowVars.CHECKSUM_OVERWRITE_FILE_ID, "")
-                == raw_file.id
+            if _is_overwrite_requested(
+                AirflowVars.CHECKSUM_OVERWRITE_FILE_ID, raw_file
             ):
                 logging.warning(
                     f"Will overwrite existing file_info as requested by Airflow variable {AirflowVars.CHECKSUM_OVERWRITE_FILE_ID}."
@@ -205,6 +205,20 @@ def _compare_file_info(
     return errors
 
 
+def _is_overwrite_requested(airflow_variable: str, raw_file: RawFile) -> bool:
+    """Check if the Airflow variable `airflow_variable` requests an overwrite for `raw_file`.
+
+    The variable either holds a single raw file id, or `INSTRUMENT_<instrument_id>` to match
+    all raw files of that instrument.
+    """
+    value = get_airflow_variable(airflow_variable, "")
+
+    return value in [
+        raw_file.id,
+        f"{INSTRUMENT_OVERWRITE_PREFIX}{raw_file.instrument_id}",
+    ]
+
+
 def copy_raw_file(ti: TaskInstance, **kwargs) -> None:
     """Copy all data associated with a raw file to the target location."""
     raw_file_id = kwargs[DagContext.PARAMS][DagParams.RAW_FILE_ID]
@@ -236,8 +250,8 @@ def copy_raw_file(ti: TaskInstance, **kwargs) -> None:
         backup_status=BackupStatus.COPYING_IN_PROGRESS,
     )
 
-    if overwrite := (
-        get_airflow_variable(AirflowVars.BACKUP_OVERWRITE_FILE_ID, "") == raw_file.id
+    if overwrite := _is_overwrite_requested(
+        AirflowVars.BACKUP_OVERWRITE_FILE_ID, raw_file
     ):
         logging.warning(
             f"Will overwrite files as requested by Airflow variable {AirflowVars.BACKUP_OVERWRITE_FILE_ID}."

--- a/airflow_src/plugins/common/keys.py
+++ b/airflow_src/plugins/common/keys.py
@@ -119,13 +119,17 @@ class InstrumentKeys:
     FILE_MOVE_DELAY_M: str = "file_move_delay_m"
 
 
+# prefix to make the `*_OVERWRITE_FILE_ID` variables match all files of one instrument
+INSTRUMENT_OVERWRITE_PREFIX = "INSTRUMENT_"
+
+
 class AirflowVars:
     """Keys for accessing Airflow Variables (set in the Airflow UI). Cf. also Readme."""
 
-    # set to a specific file name to allow overwriting it on the checksum computation
+    # set to a specific file id (or `INSTRUMENT_<instrument_id>`) to allow overwriting it on the checksum computation
     CHECKSUM_OVERWRITE_FILE_ID = "checksum_overwrite_file_id"
 
-    # set to a specific file name to allow overwriting it on the pool backup
+    # set to a specific file id (or `INSTRUMENT_<instrument_id>`) to allow overwriting it on the pool backup
     BACKUP_OVERWRITE_FILE_ID = "backup_overwrite_file_id"
 
     # whether to consider acquisition "done" if current file is "old" (> 5h) compared to youngest file

--- a/airflow_src/tests/dags/impl/test_handler_impl.py
+++ b/airflow_src/tests/dags/impl/test_handler_impl.py
@@ -10,6 +10,7 @@ from common.settings import _INSTRUMENTS
 from dags.impl.handler_impl import (
     _count_special_characters,
     _handle_file_copying,
+    _is_overwrite_requested,
     _is_settings_configured,
     _verify_copied_files,
     compute_checksum,
@@ -323,12 +324,15 @@ def test_compute_checksum_different_file_info(
         compute_checksum(ti, **kwargs)
 
 
+@pytest.mark.parametrize(
+    "airflow_variable_value", ["test_file.raw", "INSTRUMENT_instrument1"]
+)
 @patch("dags.impl.handler_impl.get_raw_file_by_id")
 @patch("dags.impl.handler_impl.RawFileWrapperFactory")
 @patch("dags.impl.handler_impl.get_file_size")
 @patch("dags.impl.handler_impl.get_file_hash")
 @patch("dags.impl.handler_impl.update_raw_file")
-@patch("dags.impl.handler_impl.get_airflow_variable", return_value="test_file.raw")
+@patch("dags.impl.handler_impl.get_airflow_variable")
 @patch("dags.impl.handler_impl.put_xcom")
 def test_compute_checksum_different_file_info_overwrite(  # noqa: PLR0913
     mock_put_xcom: MagicMock,
@@ -338,14 +342,17 @@ def test_compute_checksum_different_file_info_overwrite(  # noqa: PLR0913
     mock_get_file_size: MagicMock,
     mock_raw_file_wrapper_factory: MagicMock,
     mock_get_raw_file_by_id: MagicMock,
+    airflow_variable_value: str,
 ) -> None:
     """Test compute_checksum continues on file_info mismatch if airflow variable is set."""
     ti = MagicMock()
     kwargs = {
         "params": {"raw_file_id": "test_file.raw"},
     }
+    mock_get_airflow_variable.return_value = airflow_variable_value
     mock_raw_file = MagicMock()
     mock_raw_file.id = "test_file.raw"
+    mock_raw_file.instrument_id = "instrument1"
     mock_raw_file.file_info = {"test_file.raw": (1000, "some_other_hash")}
     mock_get_raw_file_by_id.return_value = mock_raw_file
 
@@ -598,9 +605,12 @@ def test_copy_raw_file_verify_fails(  # noqa: PLR0913
     )
 
 
+@pytest.mark.parametrize(
+    "airflow_variable_value", ["test_file.raw", "INSTRUMENT_instrument1"]
+)
 @patch("dags.impl.handler_impl.get_xcom")
 @patch("dags.impl.handler_impl.get_raw_file_by_id")
-@patch("dags.impl.handler_impl.get_airflow_variable", return_value="test_file.raw")
+@patch("dags.impl.handler_impl.get_airflow_variable")
 @patch(
     "dags.impl.handler_impl.get_backup_base_path",
     return_value=Path("some_backup_folder"),
@@ -614,12 +624,14 @@ def test_copy_raw_file_calls_update_with_correct_args_overwrite(  # noqa: PLR091
     mock_get_airflow_variable: MagicMock,
     mock_get_raw_file_by_id: MagicMock,
     mock_get_xcom: MagicMock,
+    airflow_variable_value: str,
 ) -> None:
     """Test copy_raw_file calls update with correct arguments in case overwrite is requested."""
     ti = MagicMock()
     kwargs = {
         "params": {"raw_file_id": "test_file.raw"},
     }
+    mock_get_airflow_variable.return_value = airflow_variable_value
     mock_get_xcom.side_effect = [
         {
             "/path/to/instrument/test_file.raw": "/opt/airflow/mounts/backup/test_file.raw"
@@ -629,6 +641,7 @@ def test_copy_raw_file_calls_update_with_correct_args_overwrite(  # noqa: PLR091
 
     mock_raw_file = MagicMock()
     mock_raw_file.id = "test_file.raw"
+    mock_raw_file.instrument_id = "instrument1"
     mock_get_raw_file_by_id.return_value = mock_raw_file
 
     mock_handle_file_copying.return_value = {
@@ -651,6 +664,35 @@ def test_copy_raw_file_calls_update_with_correct_args_overwrite(  # noqa: PLR091
     mock_get_airflow_variable.assert_called_once_with("backup_overwrite_file_id", "")
 
     # not repeating the checks of test_copy_raw_file_calls_update_with_correct_args
+
+
+@pytest.mark.parametrize(
+    ("airflow_variable_value", "expected"),
+    [
+        ("", False),
+        ("test_file.raw", True),
+        ("other_file.raw", False),
+        ("INSTRUMENT_instrument1", True),
+        ("INSTRUMENT_instrument2", False),
+        ("instrument1", False),
+    ],
+)
+@patch("dags.impl.handler_impl.get_airflow_variable")
+def test_is_overwrite_requested(
+    mock_get_airflow_variable: MagicMock,
+    airflow_variable_value: str,
+    expected: bool,  # noqa: FBT001
+) -> None:
+    """Test _is_overwrite_requested matches on file id and on instrument."""
+    mock_get_airflow_variable.return_value = airflow_variable_value
+    raw_file = MagicMock()
+    raw_file.id = "test_file.raw"
+    raw_file.instrument_id = "instrument1"
+
+    # when
+    assert _is_overwrite_requested("some_variable", raw_file) == expected
+
+    mock_get_airflow_variable.assert_called_once_with("some_variable", "")
 
 
 def test_verify_copied_files_raises_exception_on_size_mismatch() -> None:

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -53,6 +53,10 @@ In this case, set the `checksum_overwrite_file_id` variable to the file _id_ (no
 potential collision flags, and restart the `compute_checksum` task. The overwrite protection
 will be deactivated just for this file id and the copying should succeed.
 
+To repair multiple files at once, set the variable to `INSTRUMENT_<instrument_id>` (e.g. `INSTRUMENT_test1`):
+the overwrite protection is then deactivated for all files of that instrument.
+As this affects all files of that instrument, reset the variable right after the repair.
+
 
 ### backup_overwrite_file_id (default: None)
 In case the `file_copy` task is interrupted (e.g. manually) while a file is being copied,
@@ -61,6 +65,10 @@ due to a security mechanism.
 In this case, set the `backup_overwrite_file_id` variable to the file _id_ (not: file _name_), i.e. including
 potential collision flags, and restart the `file_copy` task. The overwrite protection
 will be deactivated just for this file id and the copying should succeed.
+
+To repair multiple files at once, set the variable to `INSTRUMENT_<instrument_id>` (e.g. `INSTRUMENT_test1`):
+the overwrite protection is then deactivated for all files of that instrument.
+As this affects all files of that instrument, reset the variable right after the repair.
 
 
 ### output_exists_mode (default: raise)


### PR DESCRIPTION
Allow to skip file checks for a whole instrument